### PR TITLE
Pass cli arguments to iterate tasks

### DIFF
--- a/tasks/iterate.js
+++ b/tasks/iterate.js
@@ -31,7 +31,7 @@ module.exports = function (grunt) {
 			}
 
 		async.eachLimit(allOptValues, opts.limit, function (curOpt, next) {
-			var task = [ inputs.join(':') ].concat('--' + opts.argName + '=' + curOpt),
+			var task = [ inputs.join(':') ].concat('--' + opts.argName + '=' + curOpt).concat(flags),
 				itTask = grunt.util.spawn({
 					grunt: true,
 					args: task

--- a/tasks/iterate.js
+++ b/tasks/iterate.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
 			callback = this.async(),
 			inputs = grunt.util.toArray(arguments),
 			flags = grunt.option.flags(),
-			arg = [ '--', opts.argName, '=', grunt.option(opts.argName)].join();
+			arg = [ '--', opts.argName, '=', grunt.option(opts.argName)].join('');
 
 			if (flags.indexOf(arg) >= 0) {
 				flags.splice(flags.indexOf(arg), 1);

--- a/tasks/iterate.js
+++ b/tasks/iterate.js
@@ -22,7 +22,13 @@ module.exports = function (grunt) {
 			}),
 			allOptValues = grunt.option(opts.argName).split(opts.separator),
 			callback = this.async(),
-			inputs = grunt.util.toArray(arguments);
+			inputs = grunt.util.toArray(arguments),
+			flags = grunt.option.flags(),
+			arg = [ '--', opts.argName, '=', grunt.option(opts.argName)].join();
+
+			if (flags.indexOf(arg) >= 0) {
+				flags.splice(flags.indexOf(arg), 1);
+			}
 
 		async.eachLimit(allOptValues, opts.limit, function (curOpt, next) {
 			var task = [ inputs.join(':') ].concat('--' + opts.argName + '=' + curOpt),


### PR DESCRIPTION
Passing cli arguments to the iterate tasks. `grunt iterate:default --key=foo,bar --verbose --custom=fooBar` should run `grunt default --key=foo --verbose --custom=fooBar` and  `grunt default --key=bar --verbose --custom=fooBar`.

Actually it runs grunt default without the cli arguments --verbose and --custom=fooBar.
